### PR TITLE
Add filter message  by tag support

### DIFF
--- a/lib/fluent/plugin/out_websocket.rb
+++ b/lib/fluent/plugin/out_websocket.rb
@@ -47,7 +47,9 @@ module Fluent
               end
             } 
             : proc{|msg| 
-              ws.send(msg)
+              if (ws.tags.empty? || (ws.tags.include? msg[0])) 
+                ws.send(msg[1])  
+              end
             }
 
             $lock.synchronize do


### PR DESCRIPTION
Suppose somebody have such request: I just wanna get messages with special tags from fluent-websocket. 

This commit add such support.
