### PR TITLE
Fixed fluent-plugin-websocket.gemspec

### DIFF
--- a/fluent-plugin-websocket.gemspec
+++ b/fluent-plugin-websocket.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "fluentd"
   gem.add_development_dependency "websocket-eventmachine-client"
   gem.add_development_dependency "msgpack"
-  gem.add_runtime_dependency "yajl"
+  gem.add_runtime_dependency "yajl-ruby"
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "em-websocket"
 end


### PR DESCRIPTION
はじめまして、ingtkといいます。

現在、gem install時に下記メッセージが表示されインストールに失敗いたします。

> ERROR:  While executing gem ... (Gem::DependencyError)
> Unable to resolve dependencies: fluent-plugin-websocket requires yajl (>= 0)

yajlのadd_runtime_dependencyの指定が誤っているため、変更いたしました。
